### PR TITLE
chore: set ver tag to dos plugin

### DIFF
--- a/plugins/dos-protection-before.conf
+++ b/plugins/dos-protection-before.conf
@@ -80,7 +80,7 @@ SecRule &TX:dos_burst_time_slice "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0-dev',\
+    ver:'dos-protection-plugin/1.0.0',\
     chain,\
     skipAfter:END-DOS-PROTECTION-CHECKS"
     SecRule &TX:dos_counter_threshold "@eq 0" \
@@ -93,7 +93,7 @@ SecRule &TX:dos_burst_time_slice "@eq 0" \
     pass,\
     t:none,\
     nolog,\
-    ver:'OWASP_CRS/3.4.0-dev',\
+    ver:'dos-protection-plugin/1.0.0',\
     chain,\
     skipAfter:END-DOS-PROTECTION-CHECKS"
     SecRule &TX:dos_counter_threshold "@eq 0" \
@@ -126,7 +126,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.4.0-dev',\
+    ver:'dos-protection-plugin/1.0.0',\
     chain"
     SecRule &IP:DOS_BLOCK_FLAG "@eq 0" \
         "setvar:'ip.dos_block_counter=+1',\
@@ -152,7 +152,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.4.0-dev',\
+    ver:'dos-protection-plugin/1.0.0',\
     setvar:'ip.dos_block_counter=+1'"
 
 
@@ -174,7 +174,7 @@ SecRule IP:DOS_BLOCK "@eq 1" \
     tag:'platform-multi',\
     tag:'paranoia-level/1',\
     tag:'attack-dos',\
-    ver:'OWASP_CRS/3.4.0-dev',\
+    ver:'dos-protection-plugin/1.0.0',\
     skipAfter:END-DOS-PROTECTION-CHECKS"
 
 
@@ -195,7 +195,7 @@ SecRule REQUEST_BASENAME "@rx .*?(\.[a-z0-9]{1,10})?$" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.4.0-dev',\
+    ver:'dos-protection-plugin/1.0.0',\
     setvar:'tx.extension=/%{TX.1}/',\
     chain"
     SecRule TX:EXTENSION "!@within %{tx.static_extensions}" \
@@ -227,7 +227,7 @@ SecRule IP:DOS_COUNTER "@ge %{tx.dos_counter_threshold}" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.4.0-dev',\
+    ver:'dos-protection-plugin/1.0.0',\
     chain"
     SecRule &IP:DOS_BURST_COUNTER "@eq 0" \
         "setvar:'ip.dos_burst_counter=1',\
@@ -248,7 +248,7 @@ SecRule IP:DOS_COUNTER "@ge %{tx.dos_counter_threshold}" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.4.0-dev',\
+    ver:'dos-protection-plugin/1.0.0',\
     chain"
     SecRule &IP:DOS_BURST_COUNTER "@ge 1" \
         "setvar:'ip.dos_burst_counter=2',\
@@ -274,7 +274,7 @@ SecRule IP:DOS_BURST_COUNTER "@ge 2" \
     tag:'attack-dos',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.4.0-dev',\
+    ver:'dos-protection-plugin/1.0.0',\
     setvar:'ip.dos_block=1',\
     expirevar:'ip.dos_block=%{tx.dos_block_timeout}'"
 
@@ -307,7 +307,7 @@ SecRule IP:DOS_BURST_COUNTER "@ge 1" \
     tag:'paranoia-level/2',\
     tag:'OWASP_CRS',\
     tag:'capec/1000/210/227/469',\
-    ver:'OWASP_CRS/3.4.0-dev',\
+    ver:'dos-protection-plugin/1.0.0',\
     setvar:'ip.dos_block=1',\
     expirevar:'ip.dos_block=%{tx.dos_block_timeout}'"
 

--- a/plugins/dos-protection-config.conf
+++ b/plugins/dos-protection-config.conf
@@ -57,9 +57,10 @@
 SecAction \
     "id:9514900,\
     phase:1,\
-    nolog,\
     pass,\
     t:none,\
+    nolog,\
+    ver:'dos-protection-plugin/1.0.0',\
     setvar:'tx.dos_burst_time_slice=60',\
     setvar:'tx.dos_counter_threshold=100',\
     setvar:'tx.dos_block_timeout=600'"
@@ -72,7 +73,8 @@ SecAction \
 SecAction \
     "id:9514910,\
     phase:1,\
-    nolog,\
     pass,\
     t:none,\
+    nolog,\
+    ver:'dos-protection-plugin/1.0.0',\
     setvar:'tx.static_extensions=/.jpg/ /.jpeg/ /.png/ /.gif/ /.js/ /.css/ /.ico/ /.svg/ /.webp/'"


### PR DESCRIPTION
Updates the plugin ver from ``OWASP_CRS/3.4.0-dev`` to ``dos-protection-plugin/1.0.0``